### PR TITLE
Dev/add tcp mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ do.sh
 .settings
 .project
 tmp
+.idea/
+sf.sf2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ Info: Fals keine `sf.sf2` vorhanden ist fragt das Programm in der Konsole ob ein
 Um den Mqtt-Player Modus zu aktivieren, muss man das Argument `--mqtt` anhängen. z.B.: `java -jar javaMidi.jar --mqtt`
 
 ### TCP Mode
-Um den TCP-Player Modus zu aktivieren, muss man das Argument `--tcp` anhängen. z.B.: `java -jar javaMidi.jar --tcp`
+Um den TCP-Player Modus zu aktivieren, muss man das Argument `--tcp` anhängen.
+Der Port 4242 ist der default Port, wenn keiner explizit angegeben ist.
+
+Beispiele:
+
+`java -jar javaMidi.jar --tcp`
+
+`java -jar javaMidi.jar --tcp 12345`
 
 Um es unter Linux zu testen, kann z.B. der folgende Befehl genutzt werden:
 
@@ -42,4 +49,4 @@ Um es unter Linux zu testen, kann z.B. der folgende Befehl genutzt werden:
 * `-m/--topicMidi (topic)` - der mqtt-topic für den playmidi trafic
 * `-q/--mqtt` - soll mqtt als eingang genutzt werden
 * `-o/--mqttOut` - soll die ui als Fernbedinung genutzt werden
-* `-t/--tcp` - soll tcp als eingang genutzt werden
+* `-t/--tcp` - soll tcp als eingang genutzt werden. Es kann ein optionaler Port angegeben werden.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Um den Mqtt-Player Modus zu aktivieren, muss man das Argument `--mqtt` anhängen
 ### TCP Mode
 Um den TCP-Player Modus zu aktivieren, muss man das Argument `--tcp` anhängen. z.B.: `java -jar javaMidi.jar --tcp`
 
+Um es unter Linux zu testen, kann z.B. der folgende Befehl genutzt werden:
+
+`echo "a c ac" | nc 127.0.0.1 4242`
+
 ## UI Erklärung
 
 * Die oberste Leiste sind die Einstellungen für das [JSON](https://github.com/ProjektionTV/Esp32MidiPlayer#json).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ Zum Ausführen werden die jar datei in `build/libs` benötigt sowie eine sountfo
 
 Info: Fals keine `sf.sf2` vorhanden ist fragt das Programm in der Konsole ob eine heruntergeladen werden soll.
 
-Um den Mqtt-Player Modus zu aktivieren muss man das Argument `--mqtt` anhängen. z.B.: `java -jar javaMidi.jar --mqtt`
+### MQTT Mode
+Um den Mqtt-Player Modus zu aktivieren, muss man das Argument `--mqtt` anhängen. z.B.: `java -jar javaMidi.jar --mqtt`
+
+### TCP Mode
+Um den TCP-Player Modus zu aktivieren, muss man das Argument `--tcp` anhängen. z.B.: `java -jar javaMidi.jar --tcp`
 
 ## UI Erklärung
 
@@ -34,3 +38,4 @@ Um den Mqtt-Player Modus zu aktivieren muss man das Argument `--mqtt` anhängen.
 * `-m/--topicMidi (topic)` - der mqtt-topic für den playmidi trafic
 * `-q/--mqtt` - soll mqtt als eingang genutzt werden
 * `-o/--mqttOut` - soll die ui als Fernbedinung genutzt werden
+* `-t/--tcp` - soll tcp als eingang genutzt werden

--- a/src/main/java/javaMidi/JavaMain.java
+++ b/src/main/java/javaMidi/JavaMain.java
@@ -1,5 +1,6 @@
 package javaMidi;
 
+import javaMidi.tcpmode.AsyncTcpServer;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -275,7 +276,17 @@ public class JavaMain {
 				break;
 			case TCP:
 				System.out.println("loading TCP");
+				startTcpServerOnPort(4242);
 				break;
+		}
+	}
+
+	private void startTcpServerOnPort(int port) {
+		AsyncTcpServer tcpServer = new AsyncTcpServer();
+		try {
+			tcpServer.listenOnPort(port);
+		} catch (IOException e) {
+			e.printStackTrace();
 		}
 	}
 

--- a/src/main/java/javaMidi/JavaMain.java
+++ b/src/main/java/javaMidi/JavaMain.java
@@ -200,7 +200,7 @@ public class JavaMain {
 	}
 
 	public static void midiDelay(long delay) {
-		if(main.window.shoudStop){
+		if(main.window != null && main.window.shoudStop){
 			main.timeout = System.currentTimeMillis();
 			return;
 		}

--- a/src/main/java/javaMidi/JavaMain.java
+++ b/src/main/java/javaMidi/JavaMain.java
@@ -151,6 +151,12 @@ public class JavaMain {
 		optRemt.setArgs(0);
 		optRemt.setLongOpt("mqttOut");
 		options.addOption(optRemt);
+
+		Option optTcp = new Option("t", "if TCP should be used as an input");
+		optTcp.setArgs(0);
+		optTcp.setLongOpt("tcp");
+		options.addOption(optTcp);
+
 		DefaultParser parser = new DefaultParser();
 		try {
 			CommandLine cli = parser.parse(options, args);
@@ -178,6 +184,8 @@ public class JavaMain {
 			mqttOut = cli.hasOption("o");
 			if (cli.hasOption("q")) {
 				new JavaMain(Mode.MQTT);
+			} else if (cli.hasOption("t")){
+				new JavaMain(Mode.TCP);
 			} else {
 				new JavaMain(Mode.GUI);
 			}
@@ -264,6 +272,9 @@ public class JavaMain {
 				break;
 			case GUI:
 				window = new Window();
+				break;
+			case TCP:
+				System.out.println("loading TCP");
 				break;
 		}
 	}

--- a/src/main/java/javaMidi/JavaMain.java
+++ b/src/main/java/javaMidi/JavaMain.java
@@ -38,6 +38,8 @@ public class JavaMain {
 	public static String MQTT_IRC_TX = "irc/tx";
 	public static String TOPIC_MIDI = "playmidi";
 
+	public static int TCP_SERVER_PORT = 4242;
+
 	public static final short DEFALT_MIDI_CHANNEL = 1;
 	public static final boolean ALLOW_PARSER_2 = true;
 	public static final int DEFALT_BPM = 240;
@@ -154,7 +156,8 @@ public class JavaMain {
 		options.addOption(optRemt);
 
 		Option optTcp = new Option("t", "if TCP should be used as an input");
-		optTcp.setArgs(0);
+		optTcp.setOptionalArg(true);
+		optTcp.setArgs(1);
 		optTcp.setLongOpt("tcp");
 		options.addOption(optTcp);
 
@@ -186,6 +189,8 @@ public class JavaMain {
 			if (cli.hasOption("q")) {
 				new JavaMain(Mode.MQTT);
 			} else if (cli.hasOption("t")){
+				String port = cli.getOptionValue("t");
+				TCP_SERVER_PORT = port == null ? TCP_SERVER_PORT : Integer.parseInt(port);
 				new JavaMain(Mode.TCP);
 			} else {
 				new JavaMain(Mode.GUI);
@@ -276,7 +281,7 @@ public class JavaMain {
 				break;
 			case TCP:
 				System.out.println("loading TCP");
-				startTcpServerOnPort(4242);
+				startTcpServerOnPort(TCP_SERVER_PORT);
 				break;
 		}
 	}

--- a/src/main/java/javaMidi/MIDI.java
+++ b/src/main/java/javaMidi/MIDI.java
@@ -66,7 +66,7 @@ public class MIDI {
 	}
 
 	public static void sendNoteOn(short note, short velocity, short channel) {
-		if(JavaMain.main.window.shoudStop)
+		if(JavaMain.main.window != null && JavaMain.main.window.shoudStop)
 			return;
 		if(JavaMain.main.txtToMidi.recording){
 			try{

--- a/src/main/java/javaMidi/Mode.java
+++ b/src/main/java/javaMidi/Mode.java
@@ -1,0 +1,6 @@
+package javaMidi;
+
+public enum Mode {
+    GUI,
+    MQTT,
+}

--- a/src/main/java/javaMidi/Mode.java
+++ b/src/main/java/javaMidi/Mode.java
@@ -3,4 +3,5 @@ package javaMidi;
 public enum Mode {
     GUI,
     MQTT,
+    TCP,
 }

--- a/src/main/java/javaMidi/classC/PsClient.java
+++ b/src/main/java/javaMidi/classC/PsClient.java
@@ -9,17 +9,21 @@ import javaMidi.JavaMain;
 
 public class PsClient {
 
-    public static void publish (String t, String d){
+    public static void publish (String topic, String data){
         if(JavaMain.mqttOut){
             MqttMessage msg = new MqttMessage();
             try{
-                msg.setPayload(d.getBytes("utf-8"));
-                JavaMain.main.client.publish(t, msg);
+                msg.setPayload(data.getBytes("utf-8"));
+                JavaMain.main.client.publish(topic, msg);
             }catch (MqttException | UnsupportedEncodingException e){
                 e.printStackTrace();
             }
         }else{
-            JavaMain.main.window.chat.setText(JavaMain.main.window.chat.getText() + t + ": " + d + "\n");
+            if (JavaMain.main.window == null){
+                System.out.printf("--> %s: %s%n", topic, data);
+                return;
+            }
+            JavaMain.main.window.chat.setText(JavaMain.main.window.chat.getText() + topic + ": " + data + "\n");
         }
     }
     

--- a/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
+++ b/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
@@ -2,6 +2,7 @@ package javaMidi.tcpmode;
 
 import javaMidi.JavaMain;
 import javaMidi.cppconv.Interface;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -53,11 +54,17 @@ public class AsyncTcpServer {
         );
     }
 
-    public void play(String midiData){
-        String payload = midiData.startsWith("{") ? midiData : "{\"midi\":\"" + midiData + "\", \"laenge\":3600}";
+    private void play(String midiData){
+        String cleanedMidiData = midiData.trim();
+        String payload = cleanedMidiData.startsWith("{") ? cleanedMidiData : generateJson(cleanedMidiData);
         playerExecutor.submit(
                 ()-> Interface.mqttCallback(JavaMain.TOPIC_MIDI, payload)
         );
+    }
+
+    private String generateJson(String data){
+        TcpMidiData tcpMidiData = new TcpMidiData(data, 3600);
+        return JavaMain.main.gson.toJson(tcpMidiData);
     }
 
     public void stop(){

--- a/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
+++ b/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
@@ -1,6 +1,7 @@
 package javaMidi.tcpmode;
 
-import javaMidi.cppconv.Song;
+import javaMidi.JavaMain;
+import javaMidi.cppconv.Interface;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -50,8 +51,9 @@ public class AsyncTcpServer {
     }
 
     public void play(String midiData){
+        String payload = midiData.startsWith("{") ? midiData : "{\"midi\":\"" + midiData + "\", \"laenge\":3600}";
         playerExecutor.submit(
-                ()-> Song.playSong(midiData, 3600)
+                ()-> Interface.mqttCallback(JavaMain.TOPIC_MIDI, payload)
         );
     }
 

--- a/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
+++ b/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
@@ -15,6 +15,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class AsyncTcpServer {
+    private static final int SOCKET_TIMEOUT_IN_MS = 10*1000;
+
     private boolean active = true;
     private final Executor serverExecutor;
     private final ExecutorService playerExecutor;
@@ -39,6 +41,7 @@ public class AsyncTcpServer {
                             InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
                             BufferedReader in = new BufferedReader(inputStreamReader)
                     ){
+                        clientSocket.setSoTimeout(SOCKET_TIMEOUT_IN_MS);
                         String midiData = in.readLine();
                         out.printf("playing: %s%n", midiData);
                         play(midiData);

--- a/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
+++ b/src/main/java/javaMidi/tcpmode/AsyncTcpServer.java
@@ -1,0 +1,50 @@
+package javaMidi.tcpmode;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public class AsyncTcpServer {
+    private boolean active = true;
+    private final Executor executor;
+    private ServerSocket serverSocket;
+
+    public AsyncTcpServer(){
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    public void listenOnPort(int port) throws IOException {
+        serverSocket = new ServerSocket(port);
+        System.out.printf("TCP server on port %d started%n", port);
+        executor.execute(
+            ()->{
+                while(active){
+                    try (
+                            Socket clientSocket = serverSocket.accept();
+                            OutputStream outputStream = clientSocket.getOutputStream();
+                            PrintWriter out = new PrintWriter(outputStream, true);
+                            InputStream inputStream = clientSocket.getInputStream();
+                            InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+                            BufferedReader in = new BufferedReader(inputStreamReader)
+                    ){
+                        String input = in.readLine();
+                        out.printf("echo: [%s]%n", input);
+                    }catch (IOException exception){
+                        exception.printStackTrace();
+                    }
+                }
+            }
+        );
+    }
+
+    public void stop(){
+        active = false;
+    }
+}

--- a/src/main/java/javaMidi/tcpmode/TcpMidiData.java
+++ b/src/main/java/javaMidi/tcpmode/TcpMidiData.java
@@ -1,0 +1,19 @@
+package javaMidi.tcpmode;
+
+public class TcpMidiData {
+    private String midi;
+    private int laenge;
+
+    public TcpMidiData(String midi, int laenge) {
+        this.midi = midi;
+        this.laenge = laenge;
+    }
+
+    public String getMidi() {
+        return midi;
+    }
+
+    public int getLaenge() {
+        return laenge;
+    }
+}


### PR DESCRIPTION
# TCP Mode
Added a simple tcp server to play raw midi data.

## Testing:
Start the server with the tcp option.
`java -jar build/libs/javaMidiBuild.jar --tcp`
or
`java -jar build/libs/javaMidiBuild.jar --tcp 12345`

Then test it by sending raw text to this port.
Under Linux this could be: 
`echo "a c ac" | nc 127.0.0.1 4242`
or
`echo "a c ac" | nc 127.0.0.1 12345`

## Untested
The mqtt mode has not been tested.
Please check, if the implementation of the mqttout option is still correct.
